### PR TITLE
`make install` on Ubuntu and FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,15 @@ OBJS =	alloc.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o \
 	var.o version.o vi.o setmode.o signame.o strlcat.o strlcpy.o \
 	reallocarray.o
 
+# set OS platform (HACKITY HACK for gmake/bsd make compat)
+OS != echo `uname 2>/dev/null` | tr 'A-Z' 'a-z' | sed -E 's/.*(bsd|linux)/\1/'
+OS ?= linux
+
 all:	${OBJS}
 	${CC} ${LDFLAGS} -o ${PROG} ${OBJS}
 
-install: all
-	install -c -s -o root -g wheel -m 555 oksh ${PREFIX}/bin
-	install -c -o root -g wheel -m 444 oksh.1 ${PREFIX}/man/man1
-	echo "${PREFIX}/bin/oksh" >> /etc/shells
+install: os
+include Makefile.${OS}
 
 clean:
 	rm -f ${PROG} *.o *~

--- a/Makefile.bsd
+++ b/Makefile.bsd
@@ -1,0 +1,18 @@
+# group in BSD is wheel
+GROUP = wheel
+SEARCH=	grep -cw "oksh" /etc/shells
+
+# only install if root
+os: all
+	@if [ "`id -un`" != "root" ]; then \
+		echo ERROR: \'make install\' requires root, su, or sudo; \
+		exit 1; \
+	fi
+
+	install -c -s -o root -g ${GROUP} -m 555 oksh ${PREFIX}/bin
+	install -c -o root -g ${GROUP} -m 444 oksh.1 ${PREFIX}/man/man1
+
+# update /etc/shells at install time only, not during upgrade
+.if	${SEARCH:sh} == 0
+	echo "${PREFIX}/bin/oksh" >> /etc/shells
+.endif

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,0 +1,17 @@
+# group in Linux is root
+GROUP = root
+
+# only update /etc/shells at install time, not during update
+UPDATE:= `grep -w oksh /etc/shells > /dev/null;\
+	[ $$? -ne 0 ] && echo "${PREFIX}/bin/oksh" >> /etc/shells`
+
+# make install can only be run by root
+os: all
+ifneq ($(shell id -un),root)
+	@echo ERROR: \'make install\' requires root, su, or sudo
+	@exit 1
+endif
+
+	install -c -s -o root -g ${GROUP} -m 555 oksh ${PREFIX}/bin
+	install -c -o root -g ${GROUP} -m 444 oksh.1 ${PREFIX}/man/man1
+	echo ${UPDATE}


### PR DESCRIPTION
Handles the following `make install` situations:

- correctly identifies group for oksh on Ubuntu as `root`, while on FreeBSD sets oksh group `wheel`
- ensures one entry in `/etc/shells`. So, an oksh update doesn't create a new entry in `/etc/shells`
- verifies user is root, a common error by non-root users on Linux. Now make fails telling user why

Due to the wackiness of gmake and bsd-make, I was forced to split logic into separate Makefiles and detect which one needs to be called. 

`Makefile`,  on Ubuntu, uses gmake and includes `Makefile.linux` whereas on FreeBSD `Makefile` uses bsd-make and includes `Makefile.bsd`, thereby `Makefile` only requires the os-native build tools.