### PR TITLE
fix linux with queue.h

### DIFF
--- a/emacs.c
+++ b/emacs.c
@@ -16,7 +16,11 @@
 
 #include "sh.h"
 #include <sys/stat.h>
+#ifdef __linux__
+#include "portable/linux/queue.h"
+#else
 #include <sys/queue.h>
+#endif
 #include <ctype.h>
 #include <locale.h>
 #include "edit.h"


### PR DESCRIPTION
<img width="800" alt="err" src="https://cloud.githubusercontent.com/assets/5959454/23150432/75816dfe-f7c1-11e6-92cc-16ebd9f2e0d0.png">

issue when not referencing queue.h for linux using GCC 6.3.1