### PR TITLE
Add AIX support

### DIFF
--- a/asprintf.c
+++ b/asprintf.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2004 Darren Tucker.
+ *
+ * Based originally on asprintf.c from OpenBSD:
+ * Copyright (c) 1997 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "pconfig.h"
+
+#ifndef HAVE_ASPRINTF
+
+#include <errno.h>
+#include <limits.h> /* for INT_MAX */
+#include <stdarg.h>
+#include <stdio.h> /* for vsnprintf */
+#include <stdlib.h>
+
+#ifndef VA_COPY
+# ifdef HAVE_VA_COPY
+#  define VA_COPY(dest, src) va_copy(dest, src)
+# else
+#  ifdef HAVE___VA_COPY
+#   define VA_COPY(dest, src) __va_copy(dest, src)
+#  else
+#   define VA_COPY(dest, src) (dest) = (src)
+#  endif
+# endif
+#endif
+
+#define INIT_SZ	128
+
+int
+vasprintf(char **str, const char *fmt, va_list ap)
+{
+	int ret;
+	va_list ap2;
+	char *string, *newstr;
+	size_t len;
+
+	if ((string = malloc(INIT_SZ)) == NULL)
+		goto fail;
+
+	VA_COPY(ap2, ap);
+	ret = vsnprintf(string, INIT_SZ, fmt, ap2);
+	va_end(ap2);
+	if (ret >= 0 && ret < INIT_SZ) { /* succeeded with initial alloc */
+		*str = string;
+	} else if (ret == INT_MAX || ret < 0) { /* Bad length */
+		free(string);
+		goto fail;
+	} else {	/* bigger than initial, realloc allowing for nul */
+		len = (size_t)ret + 1;
+		if ((newstr = realloc(string, len)) == NULL) {
+			free(string);
+			goto fail;
+		}
+		VA_COPY(ap2, ap);
+		ret = vsnprintf(newstr, len, fmt, ap2);
+		va_end(ap2);
+		if (ret < 0 || (size_t)ret >= len) { /* failed with realloc'ed string */
+			free(newstr);
+			goto fail;
+		}
+		*str = newstr;
+	}
+	return (ret);
+
+fail:
+	*str = NULL;
+	errno = ENOMEM;
+	return (-1);
+}
+
+int asprintf(char **str, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+	
+	*str = NULL;
+	va_start(ap, fmt);
+	ret = vasprintf(str, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+#endif

--- a/configure
+++ b/configure
@@ -502,6 +502,11 @@ case "x$os" in
     tflags="-D_OPENBSD_SOURCE"
     cflags="$cflags $tflags"
     ;;
+  "xAIX")
+    tflags="-D_ALL_SOURCE"
+    cflags="$cflags $tflags"
+    ldflags="-lbsd"
+    ;;
 esac
 
 cat << EOF > pconfig.h

--- a/configure
+++ b/configure
@@ -3,6 +3,21 @@
 # This configure script written by Brian Callahan <bcallah@openbsd.org>
 # and released into the Public Domain.
 
+asprintfcheck() {
+  cat << EOF > conftest.c
+#include <stdio.h>
+int main(void){asprintf(NULL,NULL);return 0;}
+EOF
+  $cc $tflags -o conftest conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.c
+    return 0
+  else
+    rm -f conftest conftest.c
+    return 1
+  fi
+}
+
 cccheck() {
   if [ ! -z "$CC" ] ; then
 cat << EOF > conftest.c
@@ -436,6 +451,15 @@ else
   fi
 fi
 
+printf "checking for asprintf... "
+asprintfcheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_ASPRINTF" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
 printf "checking for confstr... "
 confstrcheck
 if [ $? -eq 0 ] ; then
@@ -572,11 +596,11 @@ PREFIX =	$prefix
 MANDIR =	$mandir
 PROG =		$instprog
 
-OBJS =	alloc.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o eval.o \\
-	exec.o expr.o history.o io.o jobs.o lex.o mail.o main.o misc.o \\
-	path.o shf.o syn.o table.o trap.o tree.o tty.o var.o version.o vi.o \\
-	confstr.o reallocarray.o siglist.o signame.o strlcat.o strlcpy.o \\
-	strtonum.o unvis.o vis.o
+OBJS =	alloc.o asprintf.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o \\
+	emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o \\
+	main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o \\
+	version.o vi.o confstr.o reallocarray.o siglist.o signame.o \\
+	strlcat.o strlcpy.o strtonum.o unvis.o vis.o
 
 ETS =	\`grep -w \${PREFIX}/bin/\${PROG} /etc/shells > /dev/null; \\
 	[ \$\$? -ne 0 ] && echo "\${PREFIX}/bin/\${PROG}" >> /etc/shells\`

--- a/configure
+++ b/configure
@@ -236,6 +236,36 @@ EOF
   fi
 }
 
+st_mtimcheck() {
+  cat << EOF > conftest.c
+#include <sys/stat.h>
+int main(void){struct stat s;sizeof(s.st_mtim);return 0;}
+EOF
+  $cc $tflags -o conftest conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.c
+    return 0
+  else
+    rm -f conftest conftest.c
+    return 1
+  fi
+}
+
+st_mtimespeccheck() {
+  cat << EOF > conftest.c
+#include <sys/stat.h>
+int main(void){struct stat s;sizeof(s.st_mtimespec);return 0;}
+EOF
+  $cc $tflags -o conftest conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.c
+    return 0
+  else
+    rm -f conftest conftest.c
+    return 1
+  fi
+}
+
 stravischeck() {
   cat << EOF > conftest.c
 #include <stdlib.h>
@@ -563,6 +593,24 @@ printf "checking for srand_deterministic... "
 sranddeterministiccheck
 if [ $? -eq 0 ] ; then
   echo "#define HAVE_SRAND_DETERMINISTIC" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
+printf "checking for st_mtim... "
+st_mtimcheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_ST_MTIM" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
+printf "checking for st_mtimespec... "
+st_mtimespeccheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_ST_MTIMESPEC" >> pconfig.h
   echo "yes"
 else
   echo "no"

--- a/configure
+++ b/configure
@@ -206,6 +206,21 @@ EOF
   fi
 }
 
+sig_tcheck() {
+  cat << EOF > conftest.c
+#include <signal.h>
+int main(void){sizeof(sig_t);return 0;}
+EOF
+  $cc $tflags -o conftest conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.c
+    return 0
+  else
+    rm -f conftest conftest.c
+    return 1
+  fi
+}
+
 sranddeterministiccheck() {
   cat << EOF > conftest.c
 #include <stdlib.h>
@@ -530,6 +545,15 @@ printf "checking for setresuid... "
 setresuidcheck
 if [ $? -eq 0 ] ; then
   echo "#define HAVE_SETRESUID" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
+printf "checking for sig_t... "
+sig_tcheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_SIG_T" >> pconfig.h
   echo "yes"
 else
   echo "no"

--- a/configure
+++ b/configure
@@ -298,6 +298,36 @@ EOF
   fi
 }
 
+timeraddcheck() {
+  cat << EOF > conftest.c
+#include <sys/time.h>
+int main(void){struct timeval a, b, res;timeradd(&a, &b, &res);return 0;}
+EOF
+  $cc $tflags -o conftest conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.c
+    return 0
+  else
+    rm -f conftest conftest.c
+    return 1
+  fi
+}
+
+timersubcheck() {
+  cat << EOF > conftest.c
+#include <sys/time.h>
+int main(void){struct timeval a, b, res;timersub(&a, &b, &res);return 0;}
+EOF
+  $cc $tflags -o conftest conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.c
+    return 0
+  else
+    rm -f conftest conftest.c
+    return 1
+  fi
+}
+
 wflagcheck() {
   cat << EOF > conftest.c
 int main(void){return 0;}
@@ -572,6 +602,24 @@ printf "checking for sys_signame... "
 signamecheck
 if [ $? -eq 0 ] ; then
   echo "#define HAVE_SIGNAME" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
+printf "checking for timeradd... "
+timeraddcheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_TIMERADD" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
+printf "checking for timersub... "
+timersubcheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_TIMERSUB" >> pconfig.h
   echo "yes"
 else
   echo "no"

--- a/io.c
+++ b/io.c
@@ -259,6 +259,7 @@ savefd(int fd)
 	int nfd;
 
 	if (fd < FDBASE) {
+#ifdef F_DUPFD_CLOEXEC
 		nfd = fcntl(fd, F_DUPFD_CLOEXEC, FDBASE);
 		if (nfd < 0) {
 			if (errno == EBADF)
@@ -266,6 +267,16 @@ savefd(int fd)
 			else
 				errorf("too many files open in shell");
 		}
+#else
+		nfd = fcntl(fd, F_DUPFD, FDBASE);
+		if (nfd < 0) {
+			if (errno == EBADF)
+				return -1;
+			else
+				errorf("too many files open in shell");
+		}
+		fcntl(nfd, F_SETFD, FD_CLOEXEC);
+#endif
 	} else {
 		nfd = fd;
 		fcntl(nfd, F_SETFD, FD_CLOEXEC);

--- a/portable.h
+++ b/portable.h
@@ -88,6 +88,30 @@
 #define srand_deterministic(x)	srand(x)
 #endif /* !HAVE_SRAND_DETERMINISTIC */
 
+#ifndef HAVE_TIMERADD
+#define timeradd(tvp, uvp, vvp)                                         \
+        do {                                                            \
+                (vvp)->tv_sec = (tvp)->tv_sec + (uvp)->tv_sec;          \
+                (vvp)->tv_usec = (tvp)->tv_usec + (uvp)->tv_usec;       \
+                if ((vvp)->tv_usec >= 1000000) {                        \
+                        (vvp)->tv_sec++;                                \
+                        (vvp)->tv_usec -= 1000000;                      \
+                }                                                       \
+        } while (0)
+#endif /* !HAVE_TIMERADD */
+
+#ifndef HAVE_TIMERSUB
+#define timersub(tvp, uvp, vvp)                                         \
+        do {                                                            \
+                (vvp)->tv_sec = (tvp)->tv_sec - (uvp)->tv_sec;          \
+                (vvp)->tv_usec = (tvp)->tv_usec - (uvp)->tv_usec;       \
+                if ((vvp)->tv_usec < 0) {                               \
+                        (vvp)->tv_sec--;                                \
+                        (vvp)->tv_usec += 1000000;                      \
+                }                                                       \
+        } while (0)
+#endif /* !HAVE_TIMERSUB */
+
 /* struct stat compatibility */
 #ifdef __APPLE__
 #define st_mtim	st_mtimespec

--- a/portable.h
+++ b/portable.h
@@ -202,6 +202,14 @@ extern const char *const sys_signame[NSIG];
 #endif /* !HAVE_SIGLIST || !HAVE_SIGNAME */
 
 /*
+ * Types
+ */
+
+#ifndef HAVE_SIG_T
+typedef void (*sig_t) (int); 
+#endif /* !HAVE_SIG_T */
+
+/*
  * OpenBSD sys/queue.h
  */
 

--- a/portable.h
+++ b/portable.h
@@ -113,9 +113,9 @@
 #endif /* !HAVE_TIMERSUB */
 
 /* struct stat compatibility */
-#ifdef __APPLE__
+#if !defined(HAVE_ST_MTIM) && defined(HAVE_ST_MTIMESPEC)
 #define st_mtim	st_mtimespec
-#endif /* __APPLE__ */
+#endif /* !HAVE_ST_MTIM && HAVE_ST_MTIMESPEC */
 
 /* Cygwin already has a sys_signame but we want to use our own */
 #ifdef __CYGWIN__
@@ -146,6 +146,11 @@
                 }                                                       \
         } while (0)
 #endif /* !__OpenBSD__ */
+
+#if !defined(HAVE_ST_MTIM) && !defined(HAVE_ST_MTIMESPEC)
+#define timespeccmp(tsp, usp, cmp) (tsp) cmp (usp)
+#define st_mtim st_mtime
+#endif /* !HAVE_ST_MTIM && !HAVE_ST_TIMESPEC */
 
 /*
  * Prototypes

--- a/portable.h
+++ b/portable.h
@@ -26,6 +26,10 @@
 #include <mach/mach.h>
 #endif /* __APPLE__ */
 
+#ifdef _AIX
+#include <sys/file.h>
+#endif /* _AIX */
+
 #include <time.h>
 
 #include "pconfig.h"
@@ -43,13 +47,13 @@
 #endif /* !O_EXLOCK */
 
 #ifndef _PW_NAME_LEN
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(_AIX)
 #define _PW_NAME_LEN	LOGIN_NAME_MAX
 #elif defined(__NetBSD__)
 #define _PW_NAME_LEN	MAXLOGNAME
 #else
 #define _PW_NAME_LEN	MAXLOGNAME - 1
-#endif /* __linux__ || __CYGWIN__ || __NetBSD__ */
+#endif /* __linux__ || __CYGWIN__ || _AIX || __NetBSD__ */
 #endif /* !_PW_NAME_LEN */
 
 #ifndef RLIMIT_RSS
@@ -75,6 +79,15 @@
 	(y)->tv_sec = mts.tv_sec;					\
 	(y)->tv_nsec = mts.tv_nsec;
 #endif /* __APPLE__ */
+
+#ifdef _AIX
+#define VWERASE VWERSE
+#define VDISCARD VDISCRD
+#define _PATH_DEFPATH "/usr/bin:/etc:/usr/sbin:/usr/ucb:/usr/bin/X11:/sbin"
+#define WCOREFLAG 0200
+#define WCOREDUMP(x) ((x) & WCOREFLAG)
+#undef BAD
+#endif /* _AIX */
 
 #ifndef HAVE_SETRESGID
 #define setresgid(x, y, z)	setgid(x); setegid(y); setgid(z)
@@ -220,7 +233,7 @@ typedef void (*sig_t) (int);
 
 /* The following should only be necessary on non-BSD systems.  */
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(_AIX)
 
 /*	$OpenBSD: queue.h,v 1.38 2013/07/03 15:05:21 fgsch Exp $	*/
 /*	$NetBSD: queue.h,v 1.11 1996/05/16 05:17:14 mycroft Exp $	*/
@@ -866,6 +879,6 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.cqe_next);				\
 } while (0)
 
-#endif /* __linux__ */
+#endif /* __linux__ || _AIX */
 
 #endif /* !_OKSH_PORTABLE_H_ */

--- a/portable.h
+++ b/portable.h
@@ -127,6 +127,10 @@
  * Prototypes
  */
 
+#ifndef HAVE_ASPRINTF
+int asprintf(char **str, const char *fmt, ...);
+#endif /* !HAVE_ASPRINTF */
+
 #ifndef HAVE_CONFSTR
 size_t	confstr(int, char *, size_t);
 #endif /* !HAVE_CONFSTR */

--- a/rescue.sh
+++ b/rescue.sh
@@ -117,5 +117,5 @@ cc -DEMACS -DVI -o unvis.o -c unvis.c
 echo cc -DEMACS -DVI -o vis.o -c vis.c
 cc -DEMACS -DVI -o vis.o -c vis.c
 
-echo cc -o oksh alloc.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o version.o vi.o confstr.o reallocarray.o strtonum.o siglist.o signame.o strlcat.o strlcpy.o unvis.o vis.o -lc
-cc -o oksh alloc.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o version.o vi.o confstr.o reallocarray.o strtonum.o siglist.o signame.o strlcat.o strlcpy.o unvis.o vis.o -lc
+echo cc -o oksh alloc.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o version.o vi.o asprintf.o confstr.o reallocarray.o strtonum.o siglist.o signame.o strlcat.o strlcpy.o unvis.o vis.o -lc
+cc -o oksh alloc.o asprintf.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o version.o vi.o asprintf.o confstr.o reallocarray.o strtonum.o siglist.o signame.o strlcat.o strlcpy.o unvis.o vis.o -lc


### PR DESCRIPTION
Most of these changes are based upon those NattyNarwhal has made in his efforts to port oksh to AIX. Many of the changes needed to support AIX would also be needed for potential ports to other platforms such as HP-UX or Solaris. I created checks in the configure script and added implementations. For io.c and tty.c I integrated the changes he made to support systems without F_DUPFD_CLOEXEC, but wrapped them in ifdef's so F_DUPFD_CLOEXEC is used on systems which do support it. It provides protection from potential race conditions when FD_CLOEXEC is not applied atomically. 

Aside from integrating the changes from NattyNarwhal I added the asprintf implementation from the compat library of libressl and created a check for asprintf. 