### PR TITLE
fix PASE build

### DIFF
--- a/configure
+++ b/configure
@@ -534,7 +534,7 @@ case "x$os" in
   "xNetBSD")
     cflags="$cflags -D_OPENBSD_SOURCE"
     ;;
-  "xAIX")
+  "xAIX"|"xOS400")
     cflags="$cflags -D_ALL_SOURCE"
     ldflags="-lbsd"
     ;;


### PR DESCRIPTION
Tested with IBM XL C on IBM i 7.2:

```
$ ./configure && gmake -j4
checking for C compiler... cc
checking if C compiler can compile C99 without -std=c99... yes
checking for -w compiler flag... yes
checking for OS... OS400
checking for __dead... no
checking for __dead2... no
checking for asprintf... no
checking for confstr... yes
checking for pledge... no
checking for reallocarray... no
checking for setresgid... no
checking for setresuid... no
checking for sig_t... no
checking for srand_deterministic... no
checking for st_mtim... yes
checking for st_mtimespec... no
checking for stravis... no
checking for strlcat... no
checking for strlcpy... no
checking for strtonum... no
checking for strunvis... no
checking for sys_siglist... no
checking for sys_signame... no
checking for timeradd... no
checking for timersub... no
creating Makefile... done
cc -lbsd -o oksh alloc.o asprintf.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o version.o vi.o confstr.o reallocarray.o siglist.o signame.o strlcat.o strlcpy.o strtonum.o unvis.o vis.o
```

Only caveat, but it might be an IBM i problems; a build from GCC on AIX running on i doesn't encounter this:

```
$ ./oksh
./oksh: j_change: getpgrp() failed: No such file or directory
./oksh: warning: won't have full job control
THANOS$
```