### PR TITLE
Correct #elif statements in emacs.c and var.c to use defined() operator

### DIFF
--- a/emacs.c
+++ b/emacs.c
@@ -24,10 +24,10 @@
 #ifdef HAVE_CURSES
 # include <term.h>
 # include <curses.h>
-#elif HAVE_NCURSES
+#elif defined(HAVE_NCURSES)
 # include <term.h>
 # include <ncurses.h>
-#elif HAVE_NCURSESNCURSES
+#elif defined(HAVE_NCURSESNCURSES)
 # include <ncurses/term.h>
 # include <ncurses/ncurses.h>
 #endif

--- a/var.c
+++ b/var.c
@@ -18,10 +18,10 @@
 #ifdef HAVE_CURSES
 # include <term.h>
 # include <curses.h>
-#elif HAVE_NCURSES
+#elif defined(HAVE_NCURSES)
 # include <term.h>
 # include <ncurses.h>
-#elif HAVE_NCURSESNCURSES
+#elif defined(HAVE_NCURSESNCURSES)
 # include <ncurses/term.h>
 # include <ncurses/ncurses.h>
 #endif


### PR DESCRIPTION
#elif requires the use of defined to test if a macro has been defined. Otherwise an empty macro will cause a `#elif with no expression` error.