### PR TITLE
Port to Solaris

### DIFF
--- a/c_test.c
+++ b/c_test.c
@@ -291,11 +291,11 @@ test_eval(Test_env *te, Test_op op, const char *opnd1, const char *opnd2,
 	 */
 	case TO_STEQL: /* = */
 		if (te->flags & TEF_DBRACKET)
-			return gmatch(opnd1, opnd2, false);
+			return gmatch_(opnd1, opnd2, false);
 		return strcmp(opnd1, opnd2) == 0;
 	case TO_STNEQ: /* != */
 		if (te->flags & TEF_DBRACKET)
-			return !gmatch(opnd1, opnd2, false);
+			return !gmatch_(opnd1, opnd2, false);
 		return strcmp(opnd1, opnd2) != 0;
 	case TO_STLT: /* < */
 		return strcmp(opnd1, opnd2) < 0;

--- a/edit.c
+++ b/edit.c
@@ -805,7 +805,7 @@ glob_table(const char *pat, XPtrV *wp, struct table *tp)
 	struct tbl *te;
 
 	for (ktwalk(&ts, tp); (te = ktnext(&ts)); ) {
-		if (gmatch(te->name, pat, false))
+		if (gmatch_(te->name, pat, false))
 			XPput(*wp, str_save(te->name, ATEMP));
 	}
 }

--- a/eval.c
+++ b/eval.c
@@ -910,7 +910,7 @@ trimsub(char *str, char *pat, int how)
 	case '#':		/* shortest at beginning */
 		for (p = str; p <= end; p++) {
 			c = *p; *p = '\0';
-			if (gmatch(str, pat, false)) {
+			if (gmatch_(str, pat, false)) {
 				*p = c;
 				return p;
 			}
@@ -920,7 +920,7 @@ trimsub(char *str, char *pat, int how)
 	case '#'|0x80:	/* longest match at beginning */
 		for (p = end; p >= str; p--) {
 			c = *p; *p = '\0';
-			if (gmatch(str, pat, false)) {
+			if (gmatch_(str, pat, false)) {
 				*p = c;
 				return p;
 			}
@@ -929,13 +929,13 @@ trimsub(char *str, char *pat, int how)
 		break;
 	case '%':		/* shortest match at end */
 		for (p = end; p >= str; p--) {
-			if (gmatch(p, pat, false))
+			if (gmatch_(p, pat, false))
 				return str_nsave(str, p - str, ATEMP);
 		}
 		break;
 	case '%'|0x80:	/* longest match at end */
 		for (p = str; p <= end; p++) {
-			if (gmatch(p, pat, false))
+			if (gmatch_(p, pat, false))
 				return str_nsave(str, p - str, ATEMP);
 		}
 		break;
@@ -1089,7 +1089,7 @@ globit(XString *xs,	/* dest string */
 			    (name[1] == 0 || (name[1] == '.' && name[2] == 0)))
 				continue; /* always ignore . and .. */
 			if ((*name == '.' && *sp != '.') ||
-			    !gmatch(name, sp, true))
+			    !gmatch_(name, sp, true))
 				continue;
 
 			len = strlen(d->d_name) + 1;

--- a/exec.c
+++ b/exec.c
@@ -348,7 +348,7 @@ execute(struct op *volatile t,
 		for (t = t->left; t != NULL && t->type == TPAT; t = t->right) {
 			for (ap = t->vars; *ap; ap++) {
 				if ((s = evalstr(*ap, DOTILDE|DOPAT)) &&
-				    gmatch(cp, s, false))
+				    gmatch_(cp, s, false))
 					goto Found;
 			}
 		}

--- a/misc.c
+++ b/misc.c
@@ -483,7 +483,7 @@ bi_getn(const char *as, int *ai)
  */
 
 int
-gmatch(const char *s, const char *p, int isfile)
+gmatch_(const char *s, const char *p, int isfile)
 {
 	const char *se, *pe;
 

--- a/portable.h
+++ b/portable.h
@@ -26,9 +26,9 @@
 #include <mach/mach.h>
 #endif /* __APPLE__ */
 
-#ifdef _AIX
+#if defined(_AIX) || defined(__sun)
 #include <sys/file.h>
-#endif /* _AIX */
+#endif /* _AIX || __sun */
 
 #include <time.h>
 
@@ -51,9 +51,11 @@
 #define _PW_NAME_LEN	LOGIN_NAME_MAX
 #elif defined(__NetBSD__)
 #define _PW_NAME_LEN	MAXLOGNAME
+#elif defined(__sun)
+#define _PW_NAME_LEN	LOGNAME_MAX
 #else
 #define _PW_NAME_LEN	MAXLOGNAME - 1
-#endif /* __linux__ || __CYGWIN__ || _AIX || __NetBSD__ */
+#endif /* __linux__ || __CYGWIN__ || _AIX || __NetBSD__ || __sun */
 #endif /* !_PW_NAME_LEN */
 
 #ifndef RLIMIT_RSS

--- a/sh.h
+++ b/sh.h
@@ -537,7 +537,7 @@ void	change_flag(enum sh_flag, int, int);
 int	parse_args(char **, int, int *);
 int	getn(const char *, int *);
 int	bi_getn(const char *, int *);
-int	gmatch(const char *, const char *, int);
+int	gmatch_(const char *, const char *, int);
 int	has_globbing(const char *, const char *);
 const unsigned char *pat_scan(const unsigned char *, const unsigned char *,
     int);


### PR DESCRIPTION
These two commits port oksh to Solaris. One consists of an include and define in portable.h to support Solaris. 

The other renames gmatch to gmatch_ to avoid conflicts with operating system that include gmatch in libgen. This at least includes Solaris and Irix. The gmatch in the source is not compatible with gmatch implementation from libgen.

This has been tested on openindiana using the Sun Studio compiler and gcc.
