### PR TITLE
Mention MacPorts and Homebrew in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Packages
 * [pkgsrc-wip](http://pkgsrc.se/wip/oksh)
 * [Ravenports](http://www.ravenports.com/catalog/bucket_9E/ksh/standard/)
 * [Ubuntu PPA](https://launchpad.net/~dysfunctionalprogramming/+archive/ubuntu/oksh)
+* [MacPorts](https://www.macports.org/ports.php?by=name&substr=oksh)
+* [Homebrew](https://github.com/sirn/homebrew-oksh/)
 
 Using a package not listed here? Add it and send a pull request!
 


### PR DESCRIPTION
I just add oksh to MacPorts (https://github.com/macports/macports-ports/pull/4558), and also attempted to get oksh inclusion in homebrew-core (https://github.com/Homebrew/homebrew-core/pull/40817) but this repo doesn't have enough stars to eligible to be included, so I'm linking to my own tap instead. 

Thanks for porting OpenBSD ksh! It's the only shell that doesn't make me feel insane.