### PR TITLE
Use typedef for function pointer

### DIFF
--- a/emacs.c
+++ b/emacs.c
@@ -49,8 +49,10 @@ static	Area	aedit;
 #define	KEOL	1		/* ^M, ^J */
 #define	KINTR	2		/* ^G, ^C */
 
+typedef int (*kb_func)(int);
+
 struct	x_ftab {
-	int		(*xf_func)(int c);
+	kb_func		xf_func;
 	const char	*xf_name;
 	short		xf_flags;
 };
@@ -869,7 +871,7 @@ x_eot_del(int c)
 		return (x_del_char(c));
 }
 
-static void *
+static kb_func
 kb_find_hist_func(char c)
 {
 	struct kb_entry		*k;
@@ -1323,7 +1325,7 @@ kb_del(struct kb_entry *k)
 }
 
 static struct kb_entry *
-kb_add_string(void *func, void *args, char *str)
+kb_add_string(kb_func func, void *args, char *str)
 {
 	unsigned int		ele, count;
 	struct kb_entry		*k;
@@ -1358,7 +1360,7 @@ kb_add_string(void *func, void *args, char *str)
 }
 
 static struct kb_entry *
-kb_add(void *func, ...)
+kb_add(kb_func func, ...)
 {
 	va_list			ap;
 	unsigned char		ch;


### PR DESCRIPTION
ISO C does not allow converting or comparing function pointers to
`void *`.

Instead, just use a typedef for the function pointer type.