### PR TITLE
add check for timerclear and implementation

### DIFF
--- a/configure
+++ b/configure
@@ -690,6 +690,22 @@ EOF
   fi
 }
 
+timerclearcheck() {
+  cat << EOF > conftest.c
+#include <sys/time.h>
+int main(void){struct timeval a;timerclear(&a);return 0;}
+EOF
+  $cc $cflags -o conftest.o -c conftest.c > /dev/null 2>&1
+  $cc $ldflags -o conftest conftest.o > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest conftest.o conftest.c
+    return 0
+  else
+    rm -f conftest conftest.o conftest.c
+    return 1
+  fi
+}
+
 timersubcheck() {
   cat << EOF > conftest.c
 #include <sys/time.h>
@@ -898,6 +914,7 @@ if [ $doconfigure -eq 0 ] ; then
 /* #define HAVE_SIGLIST */
 /* #define HAVE_SIGNAME */
 /* #define HAVE_TIMERADD */
+/* #define HAVE_TIMERCLEAR */
 /* #define HAVE_TIMERSUB */
 EOF
   Makefile
@@ -1259,6 +1276,15 @@ printf "checking for timeradd... "
 timeraddcheck
 if [ $? -eq 0 ] ; then
   echo "#define HAVE_TIMERADD" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
+fi
+
+printf "checking for timerclear... "
+timerclearcheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_TIMERCLEAR" >> pconfig.h
   echo "yes"
 else
   echo "no"

--- a/portable.h
+++ b/portable.h
@@ -140,6 +140,10 @@
         } while (0)
 #endif /* !HAVE_TIMERADD */
 
+#ifndef HAVE_TIMERCLEAR
+#define timerclear(tvp) ((tvp)->tv_sec = (tvp)->tv_usec = 0)
+#endif /* !HAVE_TIMERCLEAR */
+
 #ifndef HAVE_TIMERSUB
 #define timersub(tvp, uvp, vvp)                                         \
         do {                                                            \


### PR DESCRIPTION
`timeradd` and `timersub` were added in d595cab75b9ec1e3a98536f5591a02d1f2d6102a but in cases where the BSD headers aren't defined we are missing `timerclear` too.