### PR TITLE
Fix clock_gettime on MacOS

### DIFF
--- a/clock_gettime.c
+++ b/clock_gettime.c
@@ -1,0 +1,42 @@
+#include "clock_gettime.h"
+
+#ifdef _OKSH_PORTABLE_MACOS_CLOCK_GETTIME_
+int clock_gettime(clock_id_t clk_id, struct timespec *ts)
+{
+        int ret = -1;
+
+        if (ts == NULL) {
+                errno = EFAULT;
+        } else if (clk_id == CLOCK_REALTIME) {
+                /* according to clock_gettime(3) */
+                struct timeval tv;
+                if (gettimeofday(&tv, NULL) == 0) {
+                        ts->tv_sec = tv.tv_sec;
+                        ts->tv_nsec = tv.tv_usec * 1000;
+                        ret = 0;
+                } /* else: unknown errno */
+        } else if (clk_id == CLOCK_MONOTONIC) {
+                static mach_timebase_info_data_t tb = {0, 0};
+                if (tb.denom != 0 || mach_timebase_info(&tb) == KERN_SUCCESS) {
+                        uint64_t t = mach_absolute_time();
+                        /* t = t * tb.numer / tb.denom */
+                        if (tb.numer != tb.denom) {
+                                uint32_t n = tb.numer, d = tb.denom;
+                                uint64_t hi = (t >> 32), lo = (t & 0xFFFFFFFF);
+                                t = hi * n;
+                                t = (t/d << 32) + ((t%d << 32) + lo*n)/d;
+                        }
+                        ts->tv_sec = t / 1000000000;
+                        ts->tv_nsec = t % 1000000000;
+                        ret = 0;
+                } else {
+                        tb.denom = 0;
+                        /* unknown errno */
+                }
+        } else {
+                errno = EINVAL;
+        }
+        return ret;
+}
+#endif /* _OKSH_PORTABLE_MACOS_CLOCK_GETTIME_ */
+

--- a/clock_gettime.h
+++ b/clock_gettime.h
@@ -1,0 +1,17 @@
+
+/* Workarounds for missing clock_gettime() on MacOS prior to v10.12 */
+#if defined(__APPLE__) && defined(__MACH__) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+#include <time.h>
+/* not compiling with CC="xcrun --sdk macosx cc" nor SDKROOT="..." */
+#if !defined(CLOCK_REALTIME) && !defined(CLOCK_MONOTONIC)
+#define _OKSH_PORTABLE_MACOS_CLOCK_GETTIME_
+#include <errno.h>
+#include <mach/clock.h>
+#include <mach/mach_time.h>
+#include <sys/time.h>
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 6
+int clock_gettime(clock_id_t clk_id, struct timespec *ts);
+#endif
+#endif /* __APPLE__ */
+

--- a/configure
+++ b/configure
@@ -31,7 +31,8 @@ OBJS =	alloc.o asprintf.o c_ksh.o c_sh.o c_test.o c_ulimit.o edit.o \\
 	emacs.o eval.o exec.o expr.o history.o io.o jobs.o lex.o mail.o \\
 	main.o misc.o path.o shf.o syn.o table.o trap.o tree.o tty.o var.o \\
 	version.o vi.o confstr.o reallocarray.o siglist.o signame.o \\
-	strlcat.o strlcpy.o strtonum.o unvis.o vis.o issetugid.o
+	strlcat.o strlcpy.o strtonum.o unvis.o vis.o issetugid.o \\
+	clock_gettime.o
 
 all: \${PROG}
 
@@ -183,6 +184,7 @@ clockgettimecheck() {
   cat << EOF > conftest.c
 #include <stdio.h>
 #include <time.h>
+#include "clock_gettime.c"
 int main(void){clock_gettime(0,NULL);return 0;}
 EOF
   $cc $cflags -o conftest.o -c conftest.c > /dev/null 2>&1

--- a/portable.h
+++ b/portable.h
@@ -22,8 +22,8 @@
 #include <sys/time.h>
 
 #ifdef __APPLE__
-#include <mach/clock.h>
-#include <mach/mach.h>
+#include <stdint.h>
+#include "clock_gettime.h"
 #endif /* __APPLE__ */
 
 #if defined(_AIX) || defined(__sun)
@@ -87,18 +87,6 @@
 #ifndef RLIMIT_NPROC
 #define	RLIMIT_NPROC	7		/* number of processes */
 #endif /* !RLIMIT_NPROC */
-
-/* Convert clock_gettime() to clock_get_time() on Max OS X */
-#ifdef __APPLE__
-#define clock_gettime(x, y)						\
-	clock_serv_t cclock;						\
-	mach_timespec_t mts;						\
-	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock); \
-	clock_get_time(cclock, &mts);					\
-	mach_port_deallocate(mach_task_self(), cclock);			\
-	(y)->tv_sec = mts.tv_sec;					\
-	(y)->tv_nsec = mts.tv_nsec;
-#endif /* __APPLE__ */
 
 #ifdef _AIX
 #define VWERASE VWERSE


### PR DESCRIPTION
* Fix detection of `clock_gettime` on MacOS
* Support `clock_gettime(CLOCK_MONOTONIC, ...)`
