### PR TITLE
Fix Haiku build

### DIFF
--- a/portable.h
+++ b/portable.h
@@ -113,7 +113,6 @@
 #define _PATH_DEFPATH ".:/boot/home/config/non-packaged/bin:/boot/home/config/bin:/boot/system/non-packaged/bin:/bin:/boot/system/apps:/boot/system/preferences"
 #define WCOREFLAG 0200
 #define WCOREDUMP(x) ((x) & WCOREFLAG)
-#define nice(x) (int)0
 #endif /* __HAIKU__ */
 
 #ifndef HAVE_SETRESGID


### PR DESCRIPTION
First of all, thanks for this repository.

I recently started to use `oksh` in many of my computers/VMs in order to enjoy some of the great OpenBSD experience when I'm not using an OpenBSD system.
One of those VMs runs Haiku R5/Beta (*their latest release*) and compiling `oksh` there throws this error:

```
In file included from config.h:28,
                 from edit.c:8:
portable.h:116:18: error: expected identifier or '(' before 'int'
  116 | #define nice(x) (int)0
      |                  ^~~
make: *** [<builtin>: edit.o] Error 1
```

Removing line 116 from `portable.h` seems to fix the issue, and the rest of the build completes just fine.
Apparently Haiku has the `unistd.h` header and `int nice(int)` is defined.

Hopefully this is useful to anyone trying to `oksh` on Haiku.