### PR TITLE
harden qnx runtime signal and prompt paths

### DIFF
--- a/confstr.c
+++ b/confstr.c
@@ -30,18 +30,37 @@
 
 #include "pconfig.h"
 
-#ifndef HAVE_CONFSTR
+#if !defined(HAVE_CONFSTR) && !defined(__QNXNTO__)
 
+#include <errno.h>
 #include <paths.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "portable.h"
 
 size_t
 confstr(int name, char *buf, size_t len)
 {
+	const char *value;
 
-	return (strlcpy(buf, _PATH_STDPATH, len) + 1);
+	switch (name) {
+#ifdef _CS_PATH
+	case _CS_PATH:
+		value = _PATH_STDPATH;
+		break;
+#endif
+	default:
+		errno = EINVAL;
+		if (len > 0 && buf != NULL)
+			buf[0] = '\0';
+		return (0);
+	}
+
+	if (len > 0 && buf != NULL)
+		strlcpy(buf, value, len);
+
+	return (strlen(value) + 1);
 }
 
-#endif /* !HAVE_CONFSTR */
+#endif /* !HAVE_CONFSTR && !__QNXNTO__ */

--- a/lex.c
+++ b/lex.c
@@ -1282,13 +1282,17 @@ dopprompt(const char *sp, int ntruncate, const char **spp, int doprint)
 				strbuf[1] = '\0';
 				break;
 			case 'h':	/* '\' 'h' shortened hostname */
-				gethostname(strbuf, sizeof strbuf);
-				p = strchr(strbuf, '.');
-				if (p)
-					*p = '\0';
-				break;
 			case 'H':	/* '\' 'H' full hostname */
-				gethostname(strbuf, sizeof strbuf);
+				if (gethostname(strbuf, sizeof strbuf) == -1) {
+					strlcpy(strbuf, "unknown", sizeof strbuf);
+					break;
+				}
+				strbuf[sizeof(strbuf) - 1] = '\0';
+				if (*cp == 'h') {
+					p = strchr(strbuf, '.');
+					if (p)
+						*p = '\0';
+				}
 				break;
 			case 'j':	/* '\' 'j' number of jobs */
 				snprintf(strbuf, sizeof strbuf, "%d",

--- a/trap.c
+++ b/trap.c
@@ -37,7 +37,8 @@ inittraps(void)
 			sigtraps[i].name = oksh_sig2str(i);
 #endif
 #if defined(HAVE_SIGLIST) && !defined(__linux__)
-			sigtraps[i].mess = sys_siglist[i];
+			sigtraps[i].mess = (i < NSIG && sys_siglist[i] != NULL) ?
+			    sys_siglist[i] : "Unknown signal";
 #else
 			static char *mess[NSIG + 1] = { NULL };
 			if (!mess[i]) {


### PR DESCRIPTION
Hello Brian, 

I put together a another PR that hardens the QNX runtime path in a few targeted spots:

- `trap.c`: make signal message handling more defensive (`sys_siglist` bounds-safe + stable fallback)
- `confstr.c`: avoid overriding libc `confstr()` on QNX
- `lex.c`: harden `PS1` hostname expansion (`\h` / `\H`) when `gethostname()` fails

I tested this with QNX SDP 8.0 in QEMU and the shell now starts cleanly, shows the expected hostname prompt, and handles basic commands/arithmetic correctly.

Quick demo from VM:

```
Startup complete
QNX oksh-smoke 8.0.0 2025/07/30-19:24:08EDT x86pc x86_64
 
# 
# 
# /system/bin/oksh
oksh-smoke# echo "
> Hi
> "

Hi

oksh-smoke# echo $((3+7))
10
oksh-smoke# 
```

Cross-builds also pass for:
- `qcc -V12.2.0,gcc_ntox86_64`
- `qcc -V12.2.0,gcc_ntoaarch64le`

Linux native build/smoke stayed fine on my side too.

Note: this PR focuses on runtime hardening. It does not yet add stronger configure-time signal detection for cross-build scenarios (`--no-thanks`), which I can experiment in a separate follow-up.


