### PR TITLE
Add antcc to supported compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Supported compilers
 * [vbcc](http://www.compilers.de/vbcc.html) (Only tested on OpenBSD/i386)
 * [chibicc](https://github.com/rui314/chibicc)
 * [kefir](https://git.sr.ht/~jprotopopov/kefir)
+* [antcc](https://codeberg.org/lsof/antcc)
 * IBM XL C/C++ Advanced Edition Version 6.0 for Mac OS X (tested on Tiger)
 
 Building with a compiler not listed here? Add it and send a pull request!


### PR DESCRIPTION
My compiler [antcc](https://codeberg.org/lsof/antcc) can build oksh.
Tested on my Linux/x86_64 system, and OpenBSD7.7/x86_64 (on a VM)