### PR TITLE
Avoid implicit pointer sign conversion

### DIFF
--- a/emacs.c
+++ b/emacs.c
@@ -78,7 +78,7 @@ typedef enum {
 /* keybindings */
 struct kb_entry {
 	TAILQ_ENTRY(kb_entry)	entry;
-	unsigned char		*seq;
+	char			*seq;
 	int			len;
 	struct x_ftab		*ftab;
 	void			*args;
@@ -1343,7 +1343,7 @@ kb_add_string(kb_func func, void *args, char *str)
 	count = strlen(str);
 
 	k = alloc(sizeof *k + count + 1, AEDIT);
-	k->seq = (unsigned char *)(k + 1);
+	k->seq = (char *)(k + 1);
 	k->len = count;
 	k->ftab = xf;
 	k->args = args ? strdup(args) : NULL;

--- a/misc.c
+++ b/misc.c
@@ -721,7 +721,8 @@ posix_cclass(const unsigned char *pattern, int test, const unsigned char **ep)
 	size_t len;
 	int rval = 0;
 
-	if ((colon = strchr(pattern, ':')) == NULL || colon[1] != MAGIC) {
+	if ((colon = (unsigned char *)strchr((char *)pattern, ':')) == NULL ||
+	    colon[1] != MAGIC) {
 		*ep = pattern - 2;
 		return -1;
 	}
@@ -729,7 +730,8 @@ posix_cclass(const unsigned char *pattern, int test, const unsigned char **ep)
 	len = (size_t)(colon - pattern);
 
 	for (cc = cclasses; cc->name != NULL; cc++) {
-		if (!strncmp(pattern, cc->name, len) && cc->name[len] == '\0') {
+		if (!strncmp((char *)pattern, cc->name, len) &&
+		    cc->name[len] == '\0') {
 			if (cc->isctype(test))
 				rval = 1;
 			break;
@@ -754,7 +756,7 @@ cclass(const unsigned char *p, int sub)
 		if ((p[0] == MAGIC && p[1] == '[' && p[2] == ':') ||
 		    (p[0] == '[' && p[1] == ':')) {
 			do {
-				const char *pp = p + (*p == MAGIC) + 2;
+				const unsigned char *pp = p + (*p == MAGIC) + 2;
 				rv = posix_cclass(pp, sub, &p);
 				switch (rv) {
 				case 1:


### PR DESCRIPTION
Pointer assignment and calls with pointer arguments require pointers
to compatible types. Using the wrong sign is a constraint violation,
since char and unsigned char are not compatible types.

kb_entry.seq is always used with functions expecting char *, so
make it a char * instead.

Use an explicit conversion to char * when calling str* functions
in posix_cclass().