### PR TITLE
add working Sortix support

### DIFF
--- a/c_ulimit.c
+++ b/c_ulimit.c
@@ -50,13 +50,25 @@ c_ulimit(char **wp)
 		{ "coredump(blocks)", RLIMIT_CORE, 512, 'c' },
 		{ "data(kbytes)", RLIMIT_DATA, 1024, 'd' },
 		{ "stack(kbytes)", RLIMIT_STACK, 1024, 's' },
+#ifndef __sortix__
 		{ "lockedmem(kbytes)", RLIMIT_MEMLOCK, 1024, 'l' },
 		{ "memory(kbytes)", RLIMIT_RSS, 1024, 'm' },
+#endif
 		{ "nofiles(descriptors)", RLIMIT_NOFILE, 1, 'n' },
+#ifndef __sortix__
 		{ "processes", RLIMIT_NPROC, 1, 'p' },
+#endif
 		{ NULL }
 	};
-	const char	*options = "HSat#f#c#d#s#l#m#n#p#";
+	const char	*options = "HSat#f#c#d#s#"
+#ifndef __sortix__
+	    "l#m#"
+#endif
+	    "n#"
+#ifndef __sortix__
+	    "p#"
+#endif
+	    ;
 	int		how = SOFT | HARD;
 	const struct limits	*l;
 	int		optc, all = 0;

--- a/configure
+++ b/configure
@@ -451,6 +451,21 @@ EOF
   fi
 }
 
+pathscheck() {
+  cat << EOF > conftest.c
+#include <paths.h>
+int main(void){return 0;}
+EOF
+  $cc $cflags -o conftest.o -c conftest.c > /dev/null 2>&1
+  if [ $? -eq 0 ] ; then
+    rm -f conftest.o conftest.c
+    return 0
+  else
+    rm -f conftest.o conftest.c
+    return 1
+  fi
+}
+
 pledgecheck() {
   cat << EOF > conftest.c
 #include <unistd.h>
@@ -1095,6 +1110,10 @@ case "x$os" in
     cflags="$cflags -D_ALL_SOURCE"
     ldflags="-lbsd"
     ;;
+  "xSortix")
+    # Sortix is POSIX-compatible; no special flags needed.
+    # configure's compile-time probes handle feature detection automatically.
+    ;;
   "xDarwin")
     if [ $xlc -eq 1 ] ; then
       echo "warning: Detected xlc on Darwin."
@@ -1257,6 +1276,15 @@ else
   else
     echo "no"
   fi
+fi
+
+printf "checking for paths.h... "
+pathscheck
+if [ $? -eq 0 ] ; then
+  echo "#define HAVE_PATHS_H" >> pconfig.h
+  echo "yes"
+else
+  echo "no"
 fi
 
 printf "checking for pledge... "

--- a/confstr.c
+++ b/confstr.c
@@ -32,7 +32,9 @@
 
 #ifndef HAVE_CONFSTR
 
+#ifdef HAVE_PATHS_H
 #include <paths.h>
+#endif
 #include <string.h>
 
 #include "portable.h"

--- a/emacs.c
+++ b/emacs.c
@@ -1040,7 +1040,7 @@ x_redraw(int limit)
 	x_adj_ok = 0;
 	if (limit == -2) {
 		int cleared = 0;
-#ifndef SMALL
+#if !defined(SMALL) && !defined(NO_CURSES)
 		if (cur_term == NULL && Flag(FTALKING))
 			initcurses();
 		if (cur_term != NULL && clear_screen != NULL) {

--- a/exec.c
+++ b/exec.c
@@ -9,7 +9,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#ifdef HAVE_PATHS_H
 #include <paths.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/main.c
+++ b/main.c
@@ -8,7 +8,9 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#ifdef HAVE_PATHS_H
 #include <paths.h>
+#endif
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/portable.h
+++ b/portable.h
@@ -18,7 +18,9 @@
 #include <stdlib.h>
 #endif /* __linux__ || __CYGWIN__ || __midipix__ */
 
+#ifndef __sortix__
 #include <sys/param.h>
+#endif
 #include <sys/time.h>
 #include <stdint.h>
 
@@ -47,6 +49,10 @@
 #define CHILD_MAX	80
 #endif /* !CHILD_MAX */
 
+#ifndef PATH_MAX
+#define PATH_MAX	4096
+#endif /* !PATH_MAX */
+
 #ifndef O_EXLOCK
 #define O_EXLOCK	0
 #endif /* !O_EXLOCK */
@@ -64,7 +70,9 @@
 #endif /* !_PATH_STDPATH */
 
 #ifndef _PW_NAME_LEN
-#if defined(__linux__) || defined(__CYGWIN__) || defined(_AIX) || defined(__midipix__) || defined(__HAIKU__) || defined(__QNXNTO__)
+#if defined(__sortix__)
+#define _PW_NAME_LEN	LOGIN_NAME_MAX
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(_AIX) || defined(__midipix__) || defined(__HAIKU__) || defined(__QNXNTO__)
 #define _PW_NAME_LEN	LOGIN_NAME_MAX
 #elif defined(__NetBSD__)
 #define _PW_NAME_LEN	MAXLOGNAME
@@ -74,8 +82,23 @@
 #define _PW_NAME_LEN	8
 #else
 #define _PW_NAME_LEN	MAXLOGNAME - 1
-#endif /* __linux__ || __CYGWIN__ || _AIX || __NetBSD__ || __sun || __midipix__ || __HAIKU__ || __QNXNTO__ */
+#endif /* __sortix__ || __linux__ || __CYGWIN__ || _AIX || __NetBSD__ || __sun || __midipix__ || __HAIKU__ || __QNXNTO__ */
 #endif /* !_PW_NAME_LEN */
+
+#ifdef __sortix__
+typedef unsigned char u_char;
+typedef unsigned short u_short;
+typedef unsigned int u_int;
+typedef unsigned long u_long;
+/* Sortix does not expose LOGIN_NAME_MAX directly */
+#ifndef LOGIN_NAME_MAX
+#define LOGIN_NAME_MAX	_POSIX_LOGIN_NAME_MAX
+#endif
+/* Sortix has no flock(); stub it as a no-op (history locking is non-critical) */
+#define flock(fd, op)	0
+/* Sortix nice() is not yet implemented; stub as no-op */
+#define nice(x)		0
+#endif /* __sortix__ */
 
 #ifndef LOCK_EX
 #define LOCK_EX	0x02
@@ -85,17 +108,17 @@
 #define LOCK_UN	0x08
 #endif /* !LOCK_UN */
 
-#ifndef RLIMIT_RSS
+#if !defined(__sortix__) && !defined(RLIMIT_RSS)
 #define	RLIMIT_RSS	5		/* resident set size */
-#endif /* !RLIMIT_RSS */
+#endif /* !__sortix__ && !RLIMIT_RSS */
 
-#ifndef RLIMIT_MEMLOCK
+#if !defined(__sortix__) && !defined(RLIMIT_MEMLOCK)
 #define	RLIMIT_MEMLOCK	6		/* locked-in-memory address space */
-#endif /* !RLIMIT_MEMLOCK */
+#endif /* !__sortix__ && !RLIMIT_MEMLOCK */
 
-#ifndef RLIMIT_NPROC
+#if !defined(__sortix__) && !defined(RLIMIT_NPROC)
 #define	RLIMIT_NPROC	7		/* number of processes */
-#endif /* !RLIMIT_NPROC */
+#endif /* !__sortix__ && !RLIMIT_NPROC */
 
 /* Convert clock_gettime() to clock_get_time() on Max OS X < 10.12 */
 #if defined(__APPLE__) && defined(__MACH__) && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200

--- a/sh.h
+++ b/sh.h
@@ -602,5 +602,7 @@ void	change_random(void);
 int	array_ref_len(const char *);
 char *	arrayname(const char *);
 void    set_array(const char *, int, char **);
+#if !defined(SMALL) && !defined(NO_CURSES)
 void	initcurses(void);
+#endif
 /* vi.c: see edit.h */

--- a/unvis.c
+++ b/unvis.c
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #include <ctype.h>
 
+#include "portable.h"
 #include "vis.h"
 
 /*

--- a/var.c
+++ b/var.c
@@ -1239,7 +1239,7 @@ set_array(const char *var, int reset, char **vals)
 	}
 }
 
-#ifndef SMALL
+#if !defined(SMALL) && !defined(NO_CURSES)
 void
 initcurses(void)
 {
@@ -1252,4 +1252,4 @@ initcurses(void)
 			del_curterm(cur_term);
 	}
 }
-#endif /* SMALL */
+#endif /* !SMALL && !NO_CURSES */

--- a/vi.c
+++ b/vi.c
@@ -1747,7 +1747,7 @@ do_clear_screen(void)
 {
 	int neednl = 1;
 
-#ifndef SMALL
+#if !defined(SMALL) && !defined(NO_CURSES)
 	if (cur_term == NULL && Flag(FTALKING))
 		initcurses();
 	if (cur_term != NULL && clear_screen != NULL) {


### PR DESCRIPTION
Sortix follows POSIX closely and omits several BSD interfaces that oksh previously assumed were available. This prevented a native Sortix build.

## Fix
- Detect `<paths.h>` and use portable path fallbacks when it is absent.
- Add Sortix-specific compatibility definitions for path and login limits.
- Avoid unavailable curses setup when curses support is disabled.
- Supply the BSD integer typedefs needed by vis/unvis.
- Stub history locking and background `nice` requests as no-ops (Sortix TODO).
- Omit unsupported resource-limit options instead of using invented IDs.
- Leave `VDISCARD` undefined when Sortix does not provide it.

## Validation
- Rebuilt oksh from scratch on `Sortix 1.1.0-dev x86_64`.
- Confirmed `ulimit -a` lists only supported Sortix limits.
- Confirmed unsupported `ulimit` resource options are rejected.

## Notes
LLM disclosure: YES. I used Antigravity CLI (model Claude Sonnet 4.6) for the initial port and Codex (model GPT 5.6 Terra) for review and fixes.
Edit: After opening this PR, I found #94, which independently contains the same NO_CURSES guard fixes in `emacs.c`, `var.c`, and `vi.c`. Those changes are also required for the Sortix build. The remaining portability changes in this PR are Sortix-specific.
